### PR TITLE
Typos and other simple fixes in type param PEP

### DIFF
--- a/pep-9999.rst
+++ b/pep-9999.rst
@@ -53,12 +53,12 @@ clear.
 variable used within a generic class. Type variables can be invariant,
 covariant, or contravariant. The concept of variance is an advanced detail
 of type theory that is not well understood by most Python developers, yet
-it they are immediately confronted with the concept today when defining their
+they are immediately confronted with the concept today when defining their
 first generic class. This PEP largely eliminates the need for most developers
 to understand the concept of variance when defining generic classes.
 
 The rules for type parameter ordering is confusing. It is normally based on
-the order which they first appear within a class declaration, function
+the order in which they first appear within a class declaration, function
 or type alias. However, this can be overridden in a class definition by
 including a "Generic" or "Protocol" base class. This PEP proposes to make
 type parameter ordering explicit in all cases.
@@ -173,7 +173,7 @@ And with the new syntax.
 Specification
 =============
 
-Type parameter declarations
+Type Parameter Declarations
 ---------------------------
 
 We propose to add new syntax for declaring type parameters for generic
@@ -211,10 +211,10 @@ Type Parameter Scopes
 ---------------------
 
 A type parameter declared as part of a generic class is valid only within the
-class body. Type parameters are also accesses when evaluating the argument list
+class body. Type parameters are also accessible when evaluating the argument list
 (base classes and any keyword arguments) that comprise the class definition.
 This allows base classes to be parameterized by these type parameters. Type
-parameters are not accessible outside of the class body, including any class
+parameters are not accessible outside of the class body, including in any class
 decorators.
 
 ::
@@ -386,6 +386,7 @@ specialized syntax for specifying variance.
 The algorithm for computing the variance of a type parameter is as follows.
 
 For each type parameter in a generic class:
+
 1. If the type parameter is variadic or a parameter specifier, it is
 always considered invariant. No further inference is needed.
 
@@ -471,7 +472,7 @@ combinations of type variables with specified and inferred variance.
 
     # A type checker should infer the variance for T1 but use the
     # specified variance for T2 and T3.
-    class ClassA[Generic[T1, T2, T3]]: ...
+    class ClassA[T1, T2, T3]: ...
 
 
 Default Type Arguments
@@ -606,7 +607,7 @@ and type aliases.
 
 ::
 
-    def func[T, R](cb: Callable[P, R]) -> Callable[P, R]: ...
+    def func[P, R](cb: Callable[P, R]) -> Callable[P, R]: ...
 
     f_spec1 = func[[str], int]
     reveal_type(f_spec1)  # (cb: Callable[[str], int]) -> Callable[[str], int]: ...
@@ -657,7 +658,7 @@ Overload elimination should also take into account bounds and constraints.
     @overload
     def func[T extends str](a: T) -> T: ...
 
-    reveal_type(func)  # overload: (a: T) -> T, (a: T -> T)
+    reveal_type(func)  # overload: (a: T) -> T, (a: T) -> T
 
     f_int = func[int]
     reveal_type(f_int)  # (a: int) -> int
@@ -713,7 +714,7 @@ annotation for an input parameter, so it is assumed that it will be solved as
 part of a call to this function. However, it's possible that the type variable
 will go unsolved if a caller passes an ``int`` value for the first argument.
 In this case, type checkers should assume that ``T`` takes on its default
-value. In this case, the default value is ```str``, so the resulting type
+value. In this case, the default value is ``str``, so the resulting type
 of the expression ``func2(0)`` would be ``Callable[[str], str]``.
 
 
@@ -726,7 +727,7 @@ Grammar Changes
 This PEP introduces two new soft keywords: "extends" and "type". It modifies
 the grammar in the following ways:
 
-1. Addition of optional type parameter clause in ``class`` and ``def`` statement.
+1. Addition of optional type parameter clause in ``class`` and ``def`` statements.
 
 ::
     


### PR DESCRIPTION
This is fixes for several typos and such. Figured it was easier to point them out this way. If I'm wrong about some of these, feel free to reject the PR and just take the changes that you agree with.